### PR TITLE
Fix warnings by removing unused import and allowing dead fields

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ use crate::material::{Interface, Material};
 
 /// 控制 SPH 模拟的参数集合。
 #[derive(Deserialize)]
+#[allow(dead_code)]
 pub struct SimConfig {
     pub grid: [usize; 3],
     pub spacing: f64,

--- a/src/force.rs
+++ b/src/force.rs
@@ -4,7 +4,7 @@
 //! 这些计算均依据 SPH 核函数完成。
 //! 当前实现采用全对遍历，在粒子数较多时效率不高。
 
-use crate::particle::{Particle, ParticleSystem};
+use crate::particle::ParticleSystem;
 use crate::sph_kernel::SPHKernel;
 use rayon::prelude::*;
 

--- a/src/material.rs
+++ b/src/material.rs
@@ -18,6 +18,7 @@ pub enum MaterialType {
 
 /// 简单的材料属性。
 #[derive(Clone, Deserialize)]
+#[allow(dead_code)]
 pub struct Material {
     pub id: usize,
     pub name: String,
@@ -46,6 +47,7 @@ pub enum InterfaceType {
 
 /// 材料界面配置。
 #[derive(Clone, Deserialize)]
+#[allow(dead_code)]
 pub struct Interface {
     pub mat_a: usize,
     pub mat_b: usize,


### PR DESCRIPTION
## Summary
- remove the unused `Particle` import in `force.rs`
- silence dead code warnings in `config.rs` and `material.rs`

## Testing
- `cargo check`