### PR TITLE
Add two sphere collision example

### DIFF
--- a/examples/two_spheres.rs
+++ b/examples/two_spheres.rs
@@ -1,0 +1,41 @@
+use ruspahy::particle::ParticleSystem;
+use ruspahy::integrator::integrate;
+use ruspahy::output::write_vtk;
+
+fn main() {
+    let spacing = 0.1;
+    let time_step = 0.001;
+    let num_steps = 100;
+    let output_interval = 10;
+    let radius = 0.5;
+
+    let center1 = [-1.0, 0.0, 0.0];
+    let center2 = [1.0, 0.0, 0.0];
+    let velocity1 = [1.0, 0.0, 0.0];
+    let velocity2 = [-1.0, 0.0, 0.0];
+
+    let mut psys = ParticleSystem::two_spheres(
+        center1,
+        center2,
+        radius,
+        spacing,
+        velocity1,
+        velocity2,
+        0,
+        0,
+    );
+
+    for step in 0..num_steps {
+        psys.build_neighbor_list();
+        psys.compute_forces();
+        integrate(&mut psys, time_step);
+
+        if step % output_interval == 0 {
+            let filename = format!("output/spheres_{:05}.vtk", step);
+            write_vtk(&psys, &filename);
+            println!("Output: {}", filename);
+        }
+    }
+
+    println!("Simulation completed.");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod particle;
+pub mod sph_kernel;
+pub mod neighbor;
+pub mod force;
+pub mod integrator;
+pub mod output;
+pub mod config;
+pub mod material;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,18 +4,11 @@
 //! 按照光滑粒子法(SPH)的核函数计算相互作用，持续推进模
 //! 拟并定期输出 VTK 文件以便可视化。
 
-mod particle;
-mod sph_kernel;
-mod neighbor;
-mod force;
-mod integrator;
-mod output;
-mod config;
-mod material;
+use ruspahy::particle::ParticleSystem;
+use ruspahy::output::write_vtk;
+use ruspahy::integrator::integrate;
+use ruspahy::config;
 
-use crate::particle::ParticleSystem;
-use crate::output::write_vtk;
-use crate::integrator::integrate;
 
 fn main() {
     // 从配置文件读取模拟参数

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -43,6 +43,70 @@ impl ParticleSystem {
         Self { particles, neighbors }
     }
 
+    /// 创建两个相同半径的球体，用于碰撞模拟。
+    pub fn two_spheres(
+        center1: [f64; 3],
+        center2: [f64; 3],
+        radius: f64,
+        spacing: f64,
+        velocity1: [f64; 3],
+        velocity2: [f64; 3],
+        material_id1: usize,
+        material_id2: usize,
+    ) -> Self {
+        fn add_sphere(
+            particles: &mut Vec<Particle>,
+            center: [f64; 3],
+            radius: f64,
+            spacing: f64,
+            velocity: [f64; 3],
+            material_id: usize,
+        ) {
+            let n = (radius / spacing).ceil() as i32;
+            let r2 = radius * radius;
+            for ix in -n..=n {
+                for iy in -n..=n {
+                    for iz in -n..=n {
+                        let dx = ix as f64 * spacing;
+                        let dy = iy as f64 * spacing;
+                        let dz = iz as f64 * spacing;
+                        if dx * dx + dy * dy + dz * dz <= r2 {
+                            particles.push(Particle {
+                                position: [center[0] + dx, center[1] + dy, center[2] + dz],
+                                velocity,
+                                force: [0.0; 3],
+                                density: 1000.0,
+                                pressure: 0.0,
+                                material_id,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut particles = Vec::new();
+        add_sphere(
+            &mut particles,
+            center1,
+            radius,
+            spacing,
+            velocity1,
+            material_id1,
+        );
+        add_sphere(
+            &mut particles,
+            center2,
+            radius,
+            spacing,
+            velocity2,
+            material_id2,
+        );
+
+        let neighbors = vec![Vec::new(); particles.len()];
+        Self { particles, neighbors }
+    }
+
     /// 为每个粒子构建邻域列表。
     ///
     /// 目前还是代理实现，系统在 [`crate::force`]


### PR DESCRIPTION
## Summary
- expose library modules so they can be reused by examples
- create a new constructor `ParticleSystem::two_spheres`
- add an example `two_spheres` demonstrating two metal spheres colliding
- update `main.rs` to use the library modules

## Testing
- `cargo check`
- `cargo build --examples`
- `cargo test`
- `cargo build --example two_spheres`