### PR TITLE
Add elastoplastic spheres example with stress output

### DIFF
--- a/examples/two_spheres.rs
+++ b/examples/two_spheres.rs
@@ -1,6 +1,32 @@
-use ruspahy::particle::ParticleSystem;
+use ruspahy::particle::{ParticleSystem, Particle};
+use ruspahy::material::{Material, MaterialType};
 use ruspahy::integrator::integrate;
 use ruspahy::output::write_vtk;
+
+fn add_sphere(psys: &mut ParticleSystem, center: [f64;3], radius: f64, spacing: f64, velocity: [f64;3], material_id: usize) {
+    let n = (radius / spacing).ceil() as i32;
+    let r2 = radius * radius;
+    for ix in -n..=n {
+        for iy in -n..=n {
+            for iz in -n..=n {
+                let dx = ix as f64 * spacing;
+                let dy = iy as f64 * spacing;
+                let dz = iz as f64 * spacing;
+                if dx*dx + dy*dy + dz*dz <= r2 {
+                    psys.particles.push(Particle {
+                        position: [center[0]+dx, center[1]+dy, center[2]+dz],
+                        velocity,
+                        force: [0.0;3],
+                        density: 1000.0,
+                        pressure: 0.0,
+                        stress: 0.0,
+                        material_id,
+                    });
+                }
+            }
+        }
+    }
+}
 
 fn main() {
     let spacing = 0.1;
@@ -14,16 +40,39 @@ fn main() {
     let velocity1 = [1.0, 0.0, 0.0];
     let velocity2 = [-1.0, 0.0, 0.0];
 
-    let mut psys = ParticleSystem::two_spheres(
-        center1,
-        center2,
-        radius,
-        spacing,
-        velocity1,
-        velocity2,
-        0,
-        0,
-    );
+    let materials = vec![
+        Material {
+            id: 0,
+            name: "steel".to_string(),
+            material_type: MaterialType::Elastoplastic,
+            density: 7800.0,
+            youngs_modulus: 2e11,
+            yield_strength: Some(2e8),
+            hardening_modulus: None,
+            damage_threshold: None,
+        },
+        Material {
+            id: 1,
+            name: "copper".to_string(),
+            material_type: MaterialType::Elastoplastic,
+            density: 8900.0,
+            youngs_modulus: 1.1e11,
+            yield_strength: Some(1e8),
+            hardening_modulus: None,
+            damage_threshold: None,
+        },
+    ];
+
+    let mut psys = ParticleSystem {
+        particles: Vec::new(),
+        neighbors: Vec::new(),
+        materials: materials.clone(),
+    };
+
+    add_sphere(&mut psys, center1, radius, spacing, velocity1, 0);
+    add_sphere(&mut psys, center2, radius, spacing, velocity2, 1);
+
+    psys.neighbors = vec![Vec::new(); psys.particles.len()];
 
     for step in 0..num_steps {
         psys.build_neighbor_list();

--- a/src/force.rs
+++ b/src/force.rs
@@ -66,6 +66,22 @@ pub fn compute_forces(psys: &mut ParticleSystem, kernel: &SPHKernel) {
         });
 }
 
+/// 根据压力值计算简化的等效应力，并考虑材料屈服
+pub fn compute_stress(psys: &mut ParticleSystem) {
+    for p in &mut psys.particles {
+        let yield_strength = psys
+            .materials
+            .get(p.material_id)
+            .and_then(|m| m.yield_strength)
+            .unwrap_or(f64::INFINITY);
+        let mut sigma = p.pressure.abs();
+        if sigma > yield_strength {
+            sigma = yield_strength;
+        }
+        p.stress = sigma;
+    }
+}
+
 /// 工具函数：求两三维点的平方距离。
 fn squared_distance(a: [f64; 3], b: [f64; 3]) -> f64 {
     (a[0] - b[0]).powi(2) + (a[1] - b[1]).powi(2) + (a[2] - b[2]).powi(2)

--- a/src/output.rs
+++ b/src/output.rs
@@ -28,9 +28,22 @@ pub fn write_vtk(psys: &ParticleSystem, filename: &str) {
         writeln!(writer, "{}", p.pressure).unwrap();
     }
 
+    writeln!(writer, "\nSCALARS stress float 1").unwrap();
+    writeln!(writer, "LOOKUP_TABLE default").unwrap();
+    for p in &psys.particles {
+        writeln!(writer, "{}", p.stress).unwrap();
+    }
+
     writeln!(writer, "\nSCALARS material_id int 1").unwrap();
     writeln!(writer, "LOOKUP_TABLE default").unwrap();
     for p in &psys.particles {
         writeln!(writer, "{}", p.material_id).unwrap();
+    }
+
+    writeln!(writer, "\nSCALARS material_type int 1").unwrap();
+    writeln!(writer, "LOOKUP_TABLE default").unwrap();
+    for p in &psys.particles {
+        let t = psys.materials[p.material_id].material_type as i32;
+        writeln!(writer, "{}", t).unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- remove `two_spheres` helper from `ParticleSystem`
- add stress and material storage to `Particle` and `ParticleSystem`
- compute von Mises-like stress with simple plastic yielding
- output stress and material type in VTK writer
- build two spheres directly in the example using elastoplastic materials

## Testing
- `cargo check --all-targets`
- `cargo test`